### PR TITLE
Port to framebuffer

### DIFF
--- a/docs/matrix.rst
+++ b/docs/matrix.rst
@@ -27,6 +27,11 @@ Matrices
 
         Get or set the color of a given pixel.
 
+    .. attribute:: framebuffer
+
+        The underlying `FrameBuffer <https://docs.micropython.org/en/latest/esp8266/library/framebuf.html>`_
+        object.
+
 .. class:: Matrix16x18
 
     A double matrix or the matrix wing.


### PR DESCRIPTION
Make the matrix use the framebuf module as its backing store, which
enables us to use all the methods on it, such as text, lines, blit, etc.

Keeps the old functions for backward compatibility.