### PR TITLE
Fix ht16k33_seg after the move to framebuffer

### DIFF
--- a/ht16k33_matrix.py
+++ b/ht16k33_matrix.py
@@ -14,19 +14,10 @@ class HT16K33:
         self.address = address
         self._temp = bytearray(1)
 
-        self._buffer = bytearray(16)
-        self._fb_buffer = bytearray(self.WIDTH * self.HEIGHT
-                                    * self.FB_BPP // 8)
-        self.framebuffer = framebuf.FrameBuffer(
-            self._fb_buffer, self.WIDTH, self.HEIGHT, self.FORMAT)
-
-        self.framebuffer.fill(0)
+        self.buffer = bytearray(16)
         self._write_cmd(_HT16K33_OSCILATOR_ON)
         self.blink_rate(0)
         self.brightness(15)
-
-        self.pixel = self.framebuffer.pixel
-        self.fill = self.framebuffer.fill
 
     def _write_cmd(self, byte):
         self._temp[0] = byte
@@ -48,11 +39,28 @@ class HT16K33:
         self._write_cmd(_HT16K33_CMD_BRIGHTNESS | brightness)
 
     def show(self):
+        self.i2c.writeto_mem(self.address, 0x00, self.buffer)
+
+
+class HT16K33Matrix:
+    def __init__(self, i2c, address=0x70):
+        super().__init__(i2c, address)
+
+        self._fb_buffer = bytearray(self.WIDTH * self.HEIGHT
+                                    * self.FB_BPP // 8)
+        self.framebuffer = framebuf.FrameBuffer(
+            self._fb_buffer, self.WIDTH, self.HEIGHT, self.FORMAT)
+
+        self.framebuffer.fill(0)
+        self.pixel = self.framebuffer.pixel
+        self.fill = self.framebuffer.fill
+
+    def show(self):
         self._copy_buf()
-        self.i2c.writeto_mem(self.address, 0x00, self._buffer)
+        super().show()
 
 
-class Matrix16x8(HT16K33):
+class Matrix16x8(HT16K33Matrix):
     WIDTH = 16
     HEIGHT = 8
     FORMAT = framebuf.MONO_HLSB
@@ -60,10 +68,10 @@ class Matrix16x8(HT16K33):
 
     def _copy_buf(self):
         for y in range(8):
-            self._buffer[y * 2] = self._fb_buffer[y]
+            self.buffer[y * 2] = self._fb_buffer[y]
 
 
-class Matrix8x8(HT16K33):
+class Matrix8x8(HT16K33Matrix):
     WIDTH = 8
     HEIGHT = 8
     FORMAT = framebuf.MONO_HLSB
@@ -72,10 +80,10 @@ class Matrix8x8(HT16K33):
     def _copy_buf(self):
         for y in range(8):
             b = self._fb_buffer[y]
-            self._buffer[y * 2] = (b >> 1) | (b << 7)
+            self.buffer[y * 2] = (b >> 1) | (b << 7)
 
 
-class Matrix8x8x2(HT16K33):
+class Matrix8x8x2(HT16K33Matrix):
     WIDTH = 8
     HEIGHT = 8
     FORMAT = framebuf.GS4_HMSB
@@ -83,7 +91,7 @@ class Matrix8x8x2(HT16K33):
 
     def _copy_buf(self):
         pixel = self.framebuffer.pixel
-        _buffer = self._buffer
+        _buffer = self.buffer
         for y in range(8):
             b = 0
             for x in range(8):

--- a/ht16k33_matrix.py
+++ b/ht16k33_matrix.py
@@ -41,6 +41,11 @@ class HT16K33:
     def show(self):
         self.i2c.writeto_mem(self.address, 0x00, self.buffer)
 
+    def fill(self, color):
+        fill = 0xff if color else 0x00
+        for i in range(16):
+            self.buffer[i] = fill
+
 
 class HT16K33Matrix:
     def __init__(self, i2c, address=0x70):


### PR DESCRIPTION
When we moved ht16k33_matrix to use framebuffer, we forgot that ht16k33_seg is also using that code, and we broke it. This should fix it.